### PR TITLE
fix(docs): correct spelling errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Transparent WiFi (TCP) to all three UART Bridge, supports both AP and STATION WiFi modes. The .ino file is the code for the ESP32. Use Arduino IDE for ESP32 to compile and upload it to the ESP32.
 I made this project in order to connect Flight equipment devices devices like (Radio, Vario FLARM), to a Flight Computer (Kobo, Smartphones etc.),  but it is not limited to that. You can use it wherever you want, but on your own risk. Read license file for more details.
 Accesspoint                                                    
-IPAdress: 192.168.4.1                                           
+IP Address: 192.168.4.1                                           
 AP SSID: LK8000                                                   
 AP Password: Flightcomputer                                       
 Used Ports:                                                                                                          
@@ -20,7 +20,7 @@ https://github.com/espressif/arduino-esp32
 
 ===============================================================
 
-In some cases the memorylayout is to small for this scetch.
+In some cases the memory layout is too small for this sketch.
 If you face this problem you can either disable Bluetooth by removing
 #define BLUETOOTH
 in config.h 
@@ -50,9 +50,9 @@ COM1 Tx <-> GPIO17
 COM2 Rx <-> GPIO15                                                                               
 COM2 Tx <-> GPIO04                                                                              
 
-NOTE: The PIN assignment has changed and may not look straigt forward (other PINs are marked as Rx/Tx), but this assignment allows to flash via USB also with hooked MAX3232 serial drivers.
+NOTE: The PIN assignment has changed and may not look straight forward (other PINs are marked as Rx/Tx), but this assignment allows to flash via USB also with hooked MAX3232 serial drivers.
 
-I recomend to start your project with a Node32s or compatible evaluation board. For a TTL to RS232 level conversion search google for "TTL RS3232 Converter"
+I recommend to start your project with a Node32s or compatible evaluation board. For a TTL to RS232 level conversion search google for "TTL RS3232 Converter"
 
 
 


### PR DESCRIPTION
## Summary

Fixes five spelling/grammar errors in the README.md documentation.

## Changes

| Correction |
|---|
| `IPAdress` → `IP Address` |
| `scetch` → `sketch` |
| `memorylayout is to small` → `memory layout is too small` (2 fixes) |
| `straigt` → `straight` |
| `recomend` → `recommend` |

All changes are limited to documentation only — no functional impact.